### PR TITLE
Speed up tests

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      max-parallel: 1
       matrix:
         distro: [rockylinux8]
         scenario: [default, renew, ca-renew]


### PR DESCRIPTION
Tests showed that at least now parallelization of tests has no negative effects. So there's no need to throttle them. This setting is now mostly if you have dependencies to other jobs or trigger stuff in external services.