### PR TITLE
Workaround for Logstash 7 compatible keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ These workarounds usually don't get their own test scenarios in molecule. They w
 All of these have the default value `false`.
 
 * `ca_ls7_workaround`: Enable pinning key parameters for a Logstash compatible key. These settings make sure the key works with a certain combination of OpenSSL and Logstash. Symptom: Logstash logs that a valid PKCS8 key is invalid.
+* `ca_ls7_workaround_cipher`: The cipher to use for the workaround (default: `PBE-SHA1-RC4-128`)
 
 ## Example Playbook ##
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ You need to have the Python library `cryptography` in version `>1.2.3` available
 * `ca_valid_time`: Valid time of new created certificates (default: `+365d`)
 * `ca_check_valid_time`: Timeframe to check if certificates will expire (default: `+2w`)
 
+### Workarounds ###
+
+Sometimes a very special combination of tools and versions requires a workaround that may only work in certain environments. We implement these usually with variables to turn them on or off. These are almost always temporary so we don't invest a lot in documentation. If you know, you need a certain setting, then activate the variable. If not, please leave it off because these workarounds usually have negative side effects.
+
+These workarounds usually don't get their own test scenarios in molecule. They will be tested in local test systems and left as they are.
+
+All of these have the default value `false`.
+
+* `ca_ls7_workaround`: Enable pinning key parameters for a Logstash compatible key. These settings make sure the key works with a certain combination of OpenSSL and Logstash. Symptom: Logstash logs that a valid PKCS8 key is invalid.
+
 ## Example Playbook ##
 
     - hosts: all

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,8 @@ ca_altname_2: "{{ ansible_fqdn }}"
 ca_altname_3: "{{ inventory_hostname }}"
 ca_ca_keylength: 2048
 
+ca_ls7_workaround: false
+
 ca_renew: false
 ca_ca_days: 3650
 ca_valid_time: +365d

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ ca_altname_3: "{{ inventory_hostname }}"
 ca_ca_keylength: 2048
 
 ca_ls7_workaround: false
+ca_ls7_workaround_cipher: PBE-SHA1-RC4-128
 
 ca_renew: false
 ca_ca_days: 3650

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -225,7 +225,7 @@
             -in {{ ca_client_ca_dir }}/{{ inventory_hostname }}.key
             -topk8
             -passin pass:{{ ca_keypassphrase | default(omit, true) }}
-            {% if ca_ls7_workaround | bool %}v1 PBE-SHA1-RC4-128{% endif %}
+            {% if ca_ls7_workaround | bool %}-v1 PBE-SHA1-RC4-128{% endif %}
             -out {{ ca_client_ca_dir }}/{{ inventory_hostname }}-pkcs8.key
             -passout pass:{{ ca_keypassphrase | default(omit, true) }}
           args:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -225,7 +225,7 @@
             -in {{ ca_client_ca_dir }}/{{ inventory_hostname }}.key
             -topk8
             -passin pass:{{ ca_keypassphrase | default(omit, true) }}
-            {% if ca_ls7_workaround | bool %}-v1 PBE-SHA1-RC4-128{% endif %}
+            {% if ca_ls7_workaround | bool %}-v1 {{ ca_ls7_workaround_cipher }}{% endif %}
             -out {{ ca_client_ca_dir }}/{{ inventory_hostname }}-pkcs8.key
             -passout pass:{{ ca_keypassphrase | default(omit, true) }}
           args:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -225,6 +225,7 @@
             -in {{ ca_client_ca_dir }}/{{ inventory_hostname }}.key
             -topk8
             -passin pass:{{ ca_keypassphrase | default(omit, true) }}
+            {% if ca_ls7_workaround | bool %}v1 PBE-SHA1-RC4-128{% endif %}
             -out {{ ca_client_ca_dir }}/{{ inventory_hostname }}-pkcs8.key
             -passout pass:{{ ca_keypassphrase | default(omit, true) }}
           args:


### PR DESCRIPTION
* Add section in Readme about workarounds
* Add a workaround that will create PKCS8 keys with valid encryption which can be read by Logstash 7