### PR TITLE
Add Debian to tested Distros

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -14,8 +14,16 @@ jobs:
 
     strategy:
       matrix:
-        distro: [rockylinux8, rockylinux9, ubuntu2204]
-        scenario: [default, renew, ca-renew]
+        distro:
+          - rockylinux8
+          - rockylinux9
+          - ubuntu2204
+          - ubuntu2404
+          - debian12
+        scenario:
+          - default
+          - renew
+          - ca-renew
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This role is tested with:
 * Rockylinux 8
 * Rockylinux 9
 * Ubuntu 22.04
+* Ubuntu 24.04
+* Debian 12
 
 ## Requirements ##
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,6 +15,10 @@ galaxy_info:
     - name: Ubuntu
       version:
         - 22.04
+        - 24.04
+    - name: Debian
+      version:
+        - 12
   galaxy_tags:
     - system
     - ca


### PR DESCRIPTION
This will add Debian 12 to our automated test pipelines.

Needs #75 to be closed for checks to finish.