### PR TITLE
Replace Rockylinux 8 with Rockylinux 10 in support/tests

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         distro:
-          - rockylinux8
           - rockylinux9
+          - rockylinux10
           - ubuntu2204
           - ubuntu2404
           - debian12

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Some files are copied to the host you're running Ansible on.
 
 This role is tested with:
 
-* Rockylinux 8
 * Rockylinux 9
+* Rockylinux 10
 * Ubuntu 22.04
 * Ubuntu 24.04
 * Debian 12

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,8 +10,8 @@ galaxy_info:
   platforms:
     - name: EL
       version:
-        - 8
         - 9
+        - 10
     - name: Ubuntu
       version:
         - 22.04


### PR DESCRIPTION
Rockylinux 8 is already EOL. Rockylinux 10 is available now for automated tests.